### PR TITLE
Add trailing newline and carrige return after exit

### DIFF
--- a/pixelterm.py
+++ b/pixelterm.py
@@ -326,6 +326,7 @@ Shortcuts:
     def quit(self):
         """Quit"""
         self.input_handler.stop()
+        print("\r", flush=True)
         return True
 
 


### PR DESCRIPTION
That should fix #2

## Summary by Sourcery

Bug Fixes:
- 在退出时打印回车符，使光标在退出后停留在新行的开头。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Print a carriage return on quit to leave the cursor at the beginning of a new line after exiting.

</details>